### PR TITLE
Drop use of deprecated network.external.name

### DIFF
--- a/assets/project/.localbeach.docker-compose.yaml
+++ b/assets/project/.localbeach.docker-compose.yaml
@@ -2,8 +2,7 @@ version: '3.7'
 
 networks:
   local_beach:
-    external:
-      name: local_beach
+    external: true
 
 volumes:
   application:


### PR DESCRIPTION
The config claims to be version 3.7, so this drops a config option that
has been deprecated with 3.5.

Fixes #33 
See https://docs.docker.com/compose/compose-file/compose-file-v3/#external-1