### PR TITLE
Allow resource-download in "legacy" instances

### DIFF
--- a/cmd/beach/cmd/helpers.go
+++ b/cmd/beach/cmd/helpers.go
@@ -77,7 +77,7 @@ func retrieveCloudStorageCredentials(instanceIdentifier string, projectNamespace
 		s := strings.SplitN(line, "=", 2)
 		if len(s) == 2 {
 			switch s[0] {
-			case "BEACH_GOOGLE_CLOUD_STORAGE_PUBLIC_BUCKET":
+			case "BEACH_GOOGLE_CLOUD_STORAGE_TARGET_BUCKET", "BEACH_GOOGLE_CLOUD_STORAGE_PUBLIC_BUCKET":
 				bucketName = s[1]
 			case "BEACH_GOOGLE_CLOUD_STORAGE_SERVICE_ACCOUNT_PRIVATE_KEY":
 				encodedPrivateKey = s[1]

--- a/cmd/beach/cmd/resource-download.go
+++ b/cmd/beach/cmd/resource-download.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/api/option"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // resourceDownloadCmd represents the resource-download command
@@ -47,8 +48,8 @@ Notes:
  - existing data in the local Neos instance will be left unchanged
  - older Beach instances may use a namespace called "beach"
 `,
-	Args:  cobra.ExactArgs(0),
-	Run:   handleResourceDownloadRun,
+	Args: cobra.ExactArgs(0),
+	Run:  handleResourceDownloadRun,
 }
 
 func init() {
@@ -97,7 +98,7 @@ func handleResourceDownloadRun(cmd *cobra.Command, args []string) {
 			log.Error(err)
 		} else {
 			source := bucket.Object(attributes.Name)
-			targetPath := sandbox.ProjectDataPersistentResourcesPath + "/" + getRelativePersistentResourcePathByHash(attributes.Name)
+			targetPath := filepath.Dir(sandbox.ProjectDataPersistentResourcesPath + "/" + getRelativePersistentResourcePathByHash(attributes.Name) + attributes.Name)
 
 			err = os.MkdirAll(targetPath, 0755)
 			if err != nil {
@@ -105,7 +106,7 @@ func handleResourceDownloadRun(cmd *cobra.Command, args []string) {
 				return
 			}
 
-			file, err := os.OpenFile(targetPath+"/"+attributes.Name, os.O_RDWR|os.O_CREATE, 0644)
+			file, err := os.OpenFile(targetPath+"/"+filepath.Base(attributes.Name), os.O_RDWR|os.O_CREATE, 0644)
 			if err != nil {
 				log.Fatal(err)
 				return


### PR DESCRIPTION
- In older instances only `BEACH_GOOGLE_CLOUD_STORAGE_TARGET_BUCKET` may
  be set. Use it like `BEACH_GOOGLE_CLOUD_STORAGE_PUBLIC_BUCKET` if seen.
- When resources have been stored in GCS as "hash/filename" download
   will fail without this change.