### PR TITLE
Custom bucket name for resource download and upload

### DIFF
--- a/cmd/beach/cmd/helpers.go
+++ b/cmd/beach/cmd/helpers.go
@@ -60,7 +60,7 @@ func readFileFromAssets(src string) string {
 func getRelativePersistentResourcePathByHash(hash string) string {
 	slashPosition := strings.Index(hash, "/")
 	if slashPosition > 0 {
-		return string(hash[0:slashPosition]) + "/" + string(hash[slashPosition+1]) + "/" + string(hash[slashPosition+2]) + "/" + string(hash[slashPosition+3])
+		return string(hash[0:slashPosition]) + "/" + string(hash[slashPosition+1]) + "/" + string(hash[slashPosition+2]) + "/" + string(hash[slashPosition+3]) + "/" + string(hash[slashPosition+4])
 	} else {
 		return string(hash[0]) + "/" + string(hash[1]) + "/" + string(hash[2]) + "/" + string(hash[3])
 	}

--- a/cmd/beach/cmd/helpers.go
+++ b/cmd/beach/cmd/helpers.go
@@ -58,7 +58,12 @@ func readFileFromAssets(src string) string {
 }
 
 func getRelativePersistentResourcePathByHash(hash string) string {
-	return string(hash[0]) + "/" + string(hash[1]) + "/" + string(hash[2]) + "/" + string(hash[3])
+	slashPosition := strings.Index(hash, "/")
+	if slashPosition > 0 {
+		return string(hash[0:slashPosition]) + "/" + string(hash[slashPosition+1]) + "/" + string(hash[slashPosition+2]) + "/" + string(hash[slashPosition+3])
+	} else {
+		return string(hash[0]) + "/" + string(hash[1]) + "/" + string(hash[2]) + "/" + string(hash[3])
+	}
 }
 
 func retrieveCloudStorageCredentials(instanceIdentifier string, projectNamespace string) (err error, bucketName string, privateKey []byte) {

--- a/cmd/beach/cmd/resource-download.go
+++ b/cmd/beach/cmd/resource-download.go
@@ -41,6 +41,10 @@ Resource data (that is, the actual files containing binary data, like images or 
 will be downloaded to the Data/Persistent/Resources directory. It is your responsibility 
 to make sure that the database content is matching this data. 
 
+The Google Cloud Storage bucket name will be determined automatically through the environment
+variables set in the given instance. You can override the bucket name by specifying the --bucket
+parameter.
+
 Be aware that Neos and Flow keep track of existing resources by a database table. If 
 resources are not registered in there, Flow does not know about them.
 
@@ -55,6 +59,7 @@ Notes:
 func init() {
 	resourceDownloadCmd.Flags().StringVar(&instanceIdentifier, "instance", "", "instance identifier of the Beach instance to download from, eg. 'instance-123abc45-def6-7890-abcd-1234567890ab'")
 	resourceDownloadCmd.Flags().StringVar(&projectNamespace, "namespace", "", "The project namespace of the Beach instance to download from, eg. 'beach-project-123abc45-def6-7890-abcd-1234567890ab'")
+	resourceDownloadCmd.Flags().StringVar(&bucketName, "bucket", "", "name of the bucket to download resources from")
 	_ = resourceDownloadCmd.MarkFlagRequired("instance")
 	_ = resourceDownloadCmd.MarkFlagRequired("namespace")
 	rootCmd.AddCommand(resourceDownloadCmd)
@@ -72,10 +77,14 @@ func handleResourceDownloadRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err, bucketName, privateKeyDecoded := retrieveCloudStorageCredentials(instanceIdentifier, projectNamespace)
+	err, bucketNameFromCredentials, privateKeyDecoded := retrieveCloudStorageCredentials(instanceIdentifier, projectNamespace)
 	if err != nil {
 		log.Fatal(err)
 		return
+	}
+
+	if bucketName == "" {
+		bucketName = bucketNameFromCredentials
 	}
 
 	ctx := context.Background()

--- a/cmd/beach/cmd/resource-upload.go
+++ b/cmd/beach/cmd/resource-upload.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var instanceIdentifier, projectNamespace, resumeWithFile string
+var instanceIdentifier, projectNamespace, bucketName, resumeWithFile string
 var force bool
 
 // resourceUploadCmd represents the resource-upload command
@@ -43,6 +43,10 @@ This command uploads Flow resources from a local Flow or Neos project to a Beach
 Resource data (that is, the actual files containing binary data, like images or documents)
 will be uploaded from the Data/Persistent/Resources directory. It is your responsibility 
 to make sure that the database content is matching this data. 
+
+The Google Cloud Storage bucket name will be determined automatically through the environment
+variables set in the given instance. You can override the bucket name by specifying the --bucket
+parameter.
 
 Be aware that Neos and Flow keep track of existing resources by a database table. If 
 resources are not registered in there, Flow does not know about them.
@@ -59,6 +63,7 @@ func init() {
 	resourceUploadCmd.Flags().StringVar(&instanceIdentifier, "instance", "", "instance identifier of the Beach instance to upload to, eg. 'instance-123abc45-def6-7890-abcd-1234567890ab'")
 	resourceUploadCmd.Flags().StringVar(&projectNamespace, "namespace", "", "The project namespace of the Beach instance to upload to, eg. 'beach-project-123abc45-def6-7890-abcd-1234567890ab'")
 	resourceUploadCmd.Flags().BoolVar(&force, "force", false, "Force uploading resources which already exist in the target bucket")
+	resourceUploadCmd.Flags().StringVar(&bucketName, "bucket", "", "name of the bucket to upload resources to")
 	resourceUploadCmd.Flags().StringVar(&resumeWithFile, "resume-with-file", "", "If specified, resume uploading resources starting with the given filename, eg. '12dcde4c13142942288c5a973caf0fa720ed2794'")
 	_ = resourceUploadCmd.MarkFlagRequired("instance")
 	_ = resourceUploadCmd.MarkFlagRequired("namespace")
@@ -77,10 +82,14 @@ func handleResourceUploadRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	err, bucketName, privateKeyDecoded := retrieveCloudStorageCredentials(instanceIdentifier, projectNamespace)
+	err, bucketNameFromCredentials, privateKeyDecoded := retrieveCloudStorageCredentials(instanceIdentifier, projectNamespace)
 	if err != nil {
 		log.Fatal(err)
 		return
+	}
+
+	if bucketName == "" {
+		bucketName = bucketNameFromCredentials
 	}
 
 	ctx := context.Background()

--- a/cmd/beach/cmd/resource-upload.go
+++ b/cmd/beach/cmd/resource-upload.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var instanceIdentifier, projectNamespace, bucketName, resumeWithFile string
+var instanceIdentifier, projectNamespace, bucketName, resourcesPath, resumeWithFile string
 var force bool
 
 // resourceUploadCmd represents the resource-upload command
@@ -63,7 +63,6 @@ func init() {
 	resourceUploadCmd.Flags().StringVar(&instanceIdentifier, "instance", "", "instance identifier of the Beach instance to upload to, eg. 'instance-123abc45-def6-7890-abcd-1234567890ab'")
 	resourceUploadCmd.Flags().StringVar(&projectNamespace, "namespace", "", "The project namespace of the Beach instance to upload to, eg. 'beach-project-123abc45-def6-7890-abcd-1234567890ab'")
 	resourceUploadCmd.Flags().BoolVar(&force, "force", false, "Force uploading resources which already exist in the target bucket")
-	resourceUploadCmd.Flags().StringVar(&bucketName, "bucket", "", "name of the bucket to upload resources to")
 	resourceUploadCmd.Flags().StringVar(&resumeWithFile, "resume-with-file", "", "If specified, resume uploading resources starting with the given filename, eg. '12dcde4c13142942288c5a973caf0fa720ed2794'")
 	_ = resourceUploadCmd.MarkFlagRequired("instance")
 	_ = resourceUploadCmd.MarkFlagRequired("namespace")
@@ -76,9 +75,12 @@ func handleResourceUploadRun(cmd *cobra.Command, args []string) {
 		log.Fatal("Could not activate sandbox: ", err)
 		return
 	}
-	_, err = os.Stat(sandbox.ProjectDataPersistentResourcesPath)
+	if resourcesPath == "" {
+		resourcesPath = sandbox.ProjectDataPersistentResourcesPath
+	}
+	_, err = os.Stat(resourcesPath)
 	if err != nil {
-		log.Fatal("The path %v does not exist", sandbox.ProjectDataPersistentResourcesPath)
+		log.Fatal("The path %v does not exist", resourcesPath)
 		return
 	}
 
@@ -99,10 +101,10 @@ func handleResourceUploadRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	log.Info(fmt.Sprintf("Uploading resources from local directory %v to bucket %v...", sandbox.ProjectDataPersistentResourcesPath, bucketName))
+	log.Info(fmt.Sprintf("Uploading resources from local directory %v to bucket %v...", resourcesPath, bucketName))
 
 	var fileList []string
-	err = filepath.Walk(sandbox.ProjectDataPersistentResourcesPath, func(path string, f os.FileInfo, err error) error {
+	err = filepath.Walk(resourcesPath, func(path string, f os.FileInfo, err error) error {
 		if !f.IsDir() {
 			fileList = append(fileList, path)
 		}


### PR DESCRIPTION
Local Beach now allows to specify a bucket name when uploading or downloading resources to or from a Beach instance. By default, the public bucket is used and automatically determined from the environment variables found in the Beach instance. However, by specifying --bucket, users can now use the private bucket instead.