### PR TITLE
Update flownative/localbeach-nginx-proxy 0.3.0 to 0.4.0

### DIFF
--- a/assets/local-beach/docker-compose.yml
+++ b/assets/local-beach/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   webserver:
-    image: flownative/localbeach-nginx-proxy:0.3.0
+    image: flownative/localbeach-nginx-proxy:0.4.0
     container_name: local_beach_nginx
     networks:
       - local_beach


### PR DESCRIPTION
This is the change to use the result of https://github.com/flownative/docker-localbeach-nginx-proxy/pull/2, assuming it was released as `0.4.0`.