### PR TITLE
TASK(proxy): more execution time because of 504 gateway timeout

### DIFF
--- a/assets/local-beach/docker-compose.yml
+++ b/assets/local-beach/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   webserver:
-    image: flownative/localbeach-nginx-proxy:0.4.0
+    image: flownative/localbeach-nginx-proxy:0.4.1
     container_name: local_beach_nginx
     networks:
       - local_beach


### PR DESCRIPTION
Sometime there are appearing 504 gateway timeouts if a script in backend takes to much time. To prevent this, i would like to add some time to proxy connection timeout. For example: build a larger script with: https://github.com/Sebobo/Shel.Neos.Terminal