### PR TITLE
Improve Flow project root detection

### DIFF
--- a/pkg/beachsandbox/helpers.go
+++ b/pkg/beachsandbox/helpers.go
@@ -40,7 +40,7 @@ func detectProjectRootPathFromWorkingDir() (rootPath string, err error) {
 func detectProjectRootPath(currentPath string) (projectRootPath string, err error) {
 	projectRootPath = path.Clean(currentPath)
 
-	if _, err := os.Stat(projectRootPath + "/flow"); err == nil {
+	if info, err := os.Stat(projectRootPath + "/flow"); err == nil && !info.IsDir() {
 		if _, err := os.Stat(projectRootPath + "/.localbeach.docker-compose.yaml"); err == nil {
 			return projectRootPath, err
 		}


### PR DESCRIPTION
Upon start `beach` check for a `flow` file upwards in the file system. It did not check if that was a directory, though – and that led to false positives if a directory named `flow` existed…