### PR TITLE
Reverse loading order of env files

### DIFF
--- a/pkg/beachsandbox/helpers.go
+++ b/pkg/beachsandbox/helpers.go
@@ -53,7 +53,7 @@ func detectProjectRootPath(currentPath string) (projectRootPath string, err erro
 }
 
 func loadLocalBeachEnvironment(projectRootPath string) (err error) {
-	envFilenames := []string{".env", ".localbeach.env", ".localbeach.dist.env"}
+	envFilenames := []string{".localbeach.dist.env", ".localbeach.env", ".env"}
 	envPathAndFilename := ""
 
 	for _, envFilename := range envFilenames {


### PR DESCRIPTION
With this change the environment variables are loaded in this order:

1. `.localbeach.dist.env`
2. `.localbeach.env`
3. `.env`

That makes it possible to override values "personally" using `.env` as expected.

Fixes #80