### PR TITLE
Make shell used by  `beach exec` a login shell

### DIFF
--- a/cmd/beach/cmd/exec.go
+++ b/cmd/beach/cmd/exec.go
@@ -46,7 +46,7 @@ func handleExecRun(cmd *cobra.Command, args []string) {
 
 	commandArgs := []string{"exec", "-ti", sandbox.ProjectName + "_php"}
 	if len(args) > 0 {
-		commandArgs = append(commandArgs, "bash", "-c", strings.Trim(fmt.Sprint(args), "[]"))
+		commandArgs = append(commandArgs, "bash", "-l", "-c", strings.Trim(fmt.Sprint(args), "[]"))
 	} else {
 		commandArgs = append(commandArgs, "bash")
 	}


### PR DESCRIPTION
This makes the shell spawned by `beach exec` when used to directly run commands in the container a login shell. That makes it read the file `~/.profile` and thus sets environment variables as expected.

With https://github.com/flownative/docker-beach-php/pull/18 the banner will still be skipped.

Fixes #82