### PR TITLE
Modernize used Docker Compose files

### DIFF
--- a/assets/local-beach/docker-compose.yml
+++ b/assets/local-beach/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3.7'
-
 networks:
   local_beach:
-    name: local_beach
+    external: true
 
 services:
   webserver:

--- a/assets/project/.localbeach.docker-compose.yaml
+++ b/assets/project/.localbeach.docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 networks:
   local_beach:
     external: true


### PR DESCRIPTION
The `version` is no longer used (nor needed) and the `name` for external networks is deprecated, too…