### PR TITLE
Drop outdated `BEACH_WAIT_FOR_SYNC` env variable

### DIFF
--- a/assets/project/.localbeach.docker-compose.yaml
+++ b/assets/project/.localbeach.docker-compose.yaml
@@ -39,7 +39,6 @@ services:
     volumes:
       - ./:/application
     environment:
-      - BEACH_WAIT_FOR_SYNC=false
       - BEACH_INSTANCE_NAME=${BEACH_PROJECT_NAME}
       - BEACH_FLOW_BASE_CONTEXT=${BEACH_FLOW_BASE_CONTEXT:-Development}
       - BEACH_FLOW_SUB_CONTEXT=${BEACH_FLOW_SUB_CONTEXT:-Instance}


### PR DESCRIPTION
This drops the `BEACH_WAIT_FOR_SYNC` env variable from the setup, as it is no longer needed without the `devkit` container and a recent PHP container.

See https://github.com/flownative/docker-beach-php/pull/19