### PR TITLE
Update MariaDB from 10.11 to 11.4 (LTS)

### DIFF
--- a/assets/local-beach/docker-compose.yml
+++ b/assets/local-beach/docker-compose.yml
@@ -17,19 +17,21 @@ services:
     environment:
       - DEFAULT_HOST=hello.localbeach.net
   database:
-    image: mariadb:10.11
+    image: mariadb:11.4
     container_name: local_beach_database
     networks:
       - local_beach
     volumes:
       - {{databasePath}}:/var/lib/mysql
     healthcheck:
-      test: "/usr/bin/mysql --user=root --password=password --execute \"SHOW DATABASES;\""
+      test: "/usr/bin/mariadb --user=root --password=password --execute \"SHOW DATABASES;\""
       interval: 3s
       timeout: 1s
       retries: 10
     environment:
       - MYSQL_ROOT_PASSWORD=password
     ports:
-      - 3307:3306
-    command: 'mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci'
+       - "3307:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci

--- a/cmd/beach/cmd/helpers.go
+++ b/cmd/beach/cmd/helpers.go
@@ -152,7 +152,7 @@ func startLocalBeach() error {
 
 	databaseStatusOutput, err := exec.RunCommand("docker", []string{"ps", "--filter", "name=local_beach_database", "--filter", "status=running", "-q"})
 	if err != nil {
-		return errors.New("failed checking status of container local_beach_database container")
+		return errors.New("failed checking status of container local_beach_database container, maybe the Docker daemon is not running")
 	}
 
 	if len(nginxStatusOutput) == 0 || len(databaseStatusOutput) == 0 {
@@ -187,6 +187,12 @@ func startLocalBeach() error {
 				return errors.New("failed to check for database server container health")
 			}
 			if strings.TrimSpace(output) == "healthy" {
+				commandArgs := []string{"exec", "local_beach_database", "mariadb-upgrade", "-u", "root", "--password=password"}
+				output, err = exec.RunCommand("docker", commandArgs)
+				if err != nil {
+					log.Error(output)
+					return errors.New("mariadb-upgrade failed")
+				}
 				break
 			}
 			if tries == 10 {

--- a/cmd/beach/cmd/start.go
+++ b/cmd/beach/cmd/start.go
@@ -71,7 +71,7 @@ func handleStartRun(cmd *cobra.Command, args []string) {
 	}
 
 	log.Debug("Creating project database (if needed) ...")
-	commandArgs = []string{"exec", "local_beach_database", "/bin/bash", "-c", "echo 'CREATE DATABASE IF NOT EXISTS `" + sandbox.ProjectName + "`' | mysql -u root --password=password"}
+	commandArgs = []string{"exec", "local_beach_database", "/bin/bash", "-c", "echo 'CREATE DATABASE IF NOT EXISTS `" + sandbox.ProjectName + "`' | mariadb -u root --password=password"}
 	output, err = exec.RunCommand("docker", commandArgs)
 	if err != nil {
 		log.Fatal(output)


### PR DESCRIPTION
This upgrades the used MariaDB from version 10.11 to the current long-term series, MariaDB 11.4, maintained until May 2029.