### PR TITLE
Bring back the name for the `local_beach` network

### DIFF
--- a/assets/local-beach/docker-compose.yml
+++ b/assets/local-beach/docker-compose.yml
@@ -1,5 +1,6 @@
 networks:
   local_beach:
+    name: local_beach
 
 services:
   webserver:


### PR DESCRIPTION
This was lost in PR #87 and halfway fixed in PR #96