### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/go.build.yaml
+++ b/.github/workflows/go.build.yaml
@@ -40,8 +40,13 @@ jobs:
             echo "--> Building project for: ${os}/${arch}"
             GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -ldflags "-X github.com/flownative/localbeach/pkg/version.Version=${GITHUB_REF#refs/*/}" -o beach .
             zip "beach_${os}_${arch}.zip" beach
-            ls -la
           done
+
+          echo "--> Building project for: windows/amd64"
+          GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-X github.com/flownative/localbeach/pkg/version.Version=${GITHUB_REF#refs/*/}" -o beach.exe .
+          zip "beach_${os}_${arch}.zip" beach.exe
+
+          ls -la
 
       - name: Archive build result (darwin/amd64)
         uses: actions/upload-artifact@v7
@@ -61,6 +66,12 @@ jobs:
           name: beach-linux
           path: beach_linux_amd64.zip
 
+      - name: Archive build result (windows)
+        uses: actions/upload-artifact@v4
+        with:
+          name: beach-windows
+          path: beach_windows_amd64.zip
+
       - name: Create Release
         uses: ncipollo/release-action@v1
         env:
@@ -68,7 +79,7 @@ jobs:
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true
-          artifacts: "beach_linux_amd64.zip,beach_darwin_amd64.zip,beach_darwin_arm64.zip"
+          artifacts: "beach_linux_amd64.zip,beach_darwin_amd64.zip,beach_darwin_arm64.zip,beach_windows_amd64.zip"
           artifactContentType: application/zip
           generateReleaseNotes: false
           makeLatest: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /bin
 /assets/compiled.go
 /beach
+/beach.exe
 go_build_main_go
 .claude/settings.local.json

--- a/pkg/beachsandbox/helpers.go
+++ b/pkg/beachsandbox/helpers.go
@@ -17,7 +17,6 @@ package beachsandbox
 import (
 	"errors"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -38,15 +37,17 @@ func detectProjectRootPathFromWorkingDir() (rootPath string, err error) {
 }
 
 func detectProjectRootPath(currentPath string) (projectRootPath string, err error) {
-	projectRootPath = path.Clean(currentPath)
+	projectRootPath = filepath.Clean(currentPath)
+	parentPath := filepath.Dir(projectRootPath)
 
 	if _, err := os.Stat(filepath.Join(projectRootPath, ".localbeach.docker-compose.yaml")); err == nil {
 		return projectRootPath, err
-	} else if projectRootPath == "/" {
+	} else if parentPath == projectRootPath {
+		// We have reached the root folder
 		return "", ErrNoLocalBeachConfigurationFound
 	}
 
-	return detectProjectRootPath(path.Dir(projectRootPath))
+	return detectProjectRootPath(parentPath)
 }
 
 func loadLocalBeachEnvironment(projectRootPath string) (err error) {

--- a/pkg/path/path_windows.go
+++ b/pkg/path/path_windows.go
@@ -1,0 +1,43 @@
+// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// 💡 See https://golang.org/cmd/go/#hdr-Build_constraints for explanation of build constraints
+
+//go:build windows
+
+package path
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+var OldBase = ""
+var Base = ""
+var Certificates = ""
+var Database = ""
+
+func init() {
+	homeDir, err := os.UserHomeDir()
+
+	if err != nil {
+		log.Fatal("Failed detecting home directory")
+		return
+	}
+
+	Base = filepath.Join(homeDir, ".LocalBeach")
+	Certificates = filepath.Join(Base, "Certificates")
+	Database = filepath.Join(Base, "MariaDB")
+}


### PR DESCRIPTION
This allows to use the `beach` command on a Windows machine, as long as `docker` is available (e.g. via an installation of Docker Desktop).