### PR TITLE
Fix exec command to work in non-TTY environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /assets/compiled.go
 /beach
 go_build_main_go
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Local Beach is a Docker-based development environment for Neos CMS and Flow Framework. It's a CLI tool written in Go that manages local development instances using Docker containers (Nginx, PHP, Redis, and MySQL).
+
+The tool provides commands to initialize, start, stop, and manage Neos/Flow projects locally, with features like resource synchronization with Beach cloud storage, HTTPS setup, and Docker container orchestration.
+
+## Build and Development Commands
+
+### Building the Project
+
+**Full build (with asset generation):**
+```bash
+make
+```
+This runs:
+- `rm -f assets/compiled.go` - removes compiled assets
+- `go generate -v` - generates embedded assets using vfsgen
+- `go install -v` - installs dependencies
+- `go build -v -ldflags "-X github.com/flownative/localbeach/pkg/version.Version=dev" -o beach` - builds binary
+
+**Quick compile (without regenerating assets):**
+```bash
+make compile
+```
+Use this during development when assets haven't changed.
+
+### Testing
+
+Currently no test files exist in the project. When running `go test ./...`, note that there's a known build failure in `cmd/beach/cmd/resource-upload.go:84:3` due to a Printf formatting directive in a logrus.Fatal call.
+
+## Architecture
+
+### Project Structure
+
+- **`cmd/beach/cmd/`** - Cobra-based CLI commands (each command in its own file)
+- **`pkg/beachsandbox/`** - Core sandbox abstraction that represents a Local Beach project instance
+- **`pkg/exec/`** - Docker command execution wrapper
+- **`pkg/path/`** - Platform-specific path handling (Darwin/Linux)
+- **`pkg/version/`** - Version information
+- **`assets/`** - Embedded template files (Docker Compose configs, env templates, etc.)
+
+### Key Concepts
+
+**BeachSandbox**: The central abstraction representing a Local Beach project. Key responsibilities:
+- Project detection via `.localbeach.docker-compose.yaml` marker file
+- Environment variable loading from `.localbeach.dist.env`, `.localbeach.env`, `.env` (in that order)
+- Flow/Neos installation detection
+- Docker Compose file path management
+
+**Project Detection**: Commands traverse up from the current directory looking for `.localbeach.docker-compose.yaml` to find the project root (see `pkg/beachsandbox/helpers.go:detectProjectRootPath`).
+
+**Asset Embedding**: Template files in `assets/` are compiled into the binary using vfsgen. During build, `go generate` runs `assets_generate.go` which embeds all files from `assets/` into `assets/compiled.go`.
+
+### Docker Architecture
+
+Local Beach uses a two-tier Docker setup:
+
+1. **Global infrastructure** (started by `beach start`):
+   - `local_beach_nginx` - Reverse proxy for all projects
+   - `local_beach_database` - Shared MySQL database server
+   - Managed by `assets/local-beach/docker-compose.yml`
+
+2. **Project-specific containers**:
+   - Defined in `.localbeach.docker-compose.yaml` per project
+   - Each project gets its own PHP-FPM container and services
+   - Projects access the database at `http://{project-name}.localbeach.net`
+
+### Important File Locations
+
+**macOS:**
+- Base path: `~/Library/Application Support/Flownative/Local Beach/`
+
+**Linux/Other:**
+- Base path: `~/.Flownative/Local Beach/`
+
+These paths are defined in `pkg/path/path_darwin.go` and `pkg/path/path_linux.go`.
+
+## Common Development Patterns
+
+### Adding a New Command
+
+1. Create a new file in `cmd/beach/cmd/` (e.g., `my-command.go`)
+2. Define a `cobra.Command` struct with Use, Short, Long, Args, and Run fields
+3. Add `rootCmd.AddCommand(myCmd)` in the `init()` function
+4. Implement the `handleMyCommandRun` function
+5. Use `beachsandbox.GetActiveSandbox()` to get the current project context if needed
+6. Use `pkg/exec.RunCommand()` or `pkg/exec.RunInteractiveCommand()` for Docker operations
+
+### Environment Variable Handling
+
+Environment files are loaded in order (later files override earlier ones):
+1. `.localbeach.dist.env` - Committed defaults
+2. `.localbeach.env` - Local overrides
+3. `.env` - Additional local config
+
+Variables are parsed and set via `loadLocalBeachEnvironment()` in `pkg/beachsandbox/helpers.go`.
+
+### Resource Path Calculation
+
+Flow/Neos persistent resources use a hash-based directory structure. The `getRelativePersistentResourcePathByHash()` function in `cmd/beach/cmd/helpers.go` converts resource hashes to their filesystem path structure.
+
+### Docker Command Execution and TTY Detection
+
+The `pkg/exec` package provides two methods for executing Docker commands:
+
+- **`RunInteractiveCommand()`**: Connects stdin/stdout/stderr for interactive sessions
+- **`RunCommand()`**: Captures output without connecting stdin
+
+**TTY Detection Pattern** (see `cmd/beach/cmd/exec.go`):
+
+Commands that need to work both interactively (user's terminal) and programmatically (automation tools, Claude Code) should detect TTY availability:
+
+```go
+// Use syscall.TIOCGETA ioctl for reliable TTY detection
+var termios syscall.Termios
+_, _, errno := syscall.Syscall6(syscall.SYS_IOCTL, os.Stdin.Fd(),
+    syscall.TIOCGETA, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+isTTY := errno == 0
+```
+
+This is more reliable than `os.Stat().Mode() & os.ModeCharDevice` which can incorrectly report TTY availability.
+
+**Docker Exec Flags**:
+- Interactive (TTY available): Use `-t -i` flags (allocate pseudo-TTY + keep stdin open)
+- Non-interactive: Omit all flags (Docker's `-t` flag requires a real TTY)
+
+**Error Handling**: When using `RunCommand()` in non-TTY mode, print output before checking errors so users see command output even on failure.
+
+## Version Management
+
+The version is injected at build time via ldflags:
+```
+-ldflags "-X github.com/flownative/localbeach/pkg/version.Version=dev"
+```
+
+For releases, replace "dev" with the actual version number.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ For a slightly quicker build, use `make compile`.
 This library was developed by Robert Lemke with major contributions by Karsten Dambekalns and Christian Müller. Feel 
 free to suggest new features, report bugs or provide bug fixes in our GitHub  project.
 
-Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller, licensed under the Apache License, version 2.0.
+Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller, licensed under the Apache License, version 2.0.

--- a/cmd/beach/cmd/down.go
+++ b/cmd/beach/cmd/down.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/exec.go
+++ b/cmd/beach/cmd/exec.go
@@ -16,11 +16,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+
 	"github.com/flownative/localbeach/pkg/beachsandbox"
 	"github.com/flownative/localbeach/pkg/exec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 // execCmd represents the exec command
@@ -43,17 +47,36 @@ func handleExecRun(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	commandArgs := []string{"exec", "-ti", sandbox.ProjectName + "_php"}
+	// Check if stdin is a TTY using syscall (more reliable than Mode check)
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall6(syscall.SYS_IOCTL, os.Stdin.Fd(), syscall.TIOCGETA, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	isTTY := errno == 0
+
+	// Build Docker exec command with appropriate flags
+	commandArgs := []string{"exec"}
+	if isTTY {
+		commandArgs = append(commandArgs, "-t", "-i")
+	}
+	// Note: No -i flag when not TTY since stdin isn't connected in RunCommand
+	commandArgs = append(commandArgs, sandbox.ProjectName+"_php")
 	if len(args) > 0 {
 		commandArgs = append(commandArgs, "bash", "-l", "-c", strings.Trim(fmt.Sprint(args), "[]"))
 	} else {
 		commandArgs = append(commandArgs, "bash")
 	}
 
-	err = exec.RunInteractiveCommand("docker", commandArgs)
-	if err != nil {
-		log.Fatal(err)
-		return
+	// Use the appropriate execution method based on TTY detection
+	if isTTY {
+		err = exec.RunInteractiveCommand("docker", commandArgs)
+		if err != nil {
+			log.Fatal(err)
+			return
+		}
+	} else {
+		output, err := exec.RunCommand("docker", commandArgs)
+		fmt.Print(output)
+		if err != nil {
+			os.Exit(1)
+		}
 	}
-	return
 }

--- a/cmd/beach/cmd/exec.go
+++ b/cmd/beach/cmd/exec.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/helpers.go
+++ b/cmd/beach/cmd/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/init.go
+++ b/cmd/beach/cmd/init.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/logs.go
+++ b/cmd/beach/cmd/logs.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/pause.go
+++ b/cmd/beach/cmd/pause.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/resource-download.go
+++ b/cmd/beach/cmd/resource-download.go
@@ -15,19 +15,19 @@
 package cmd
 
 import (
-	"cloud.google.com/go/storage"
-	"context"
-	"errors"
-	"fmt"
-	"github.com/flownative/localbeach/pkg/beachsandbox"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
-	"io"
-	"os"
-	"path/filepath"
-	"hash/crc32"
+    "cloud.google.com/go/storage"
+    "context"
+    "errors"
+    "fmt"
+    "github.com/flownative/localbeach/pkg/beachsandbox"
+    log "github.com/sirupsen/logrus"
+    "github.com/spf13/cobra"
+    "google.golang.org/api/iterator"
+    "google.golang.org/api/option"
+    "hash/crc32"
+    "io"
+    "os"
+    "path/filepath"
 )
 
 var sourceBucketName, targetResourcesPath string
@@ -35,9 +35,9 @@ var synchronize bool
 
 // resourceDownloadCmd represents the resource-download command
 var resourceDownloadCmd = &cobra.Command{
-	Use:   "resource-download",
-	Short: "Download resources (assets) from a local Flow or Neos installation to Beach",
-	Long: `resource-download
+    Use:   "resource-download",
+    Short: "Download resources (assets) from a local Flow or Neos installation to Beach",
+    Long: `resource-download
 
 This command downloads Flow resources from a Beach instance to a local Flow or Neos project. 
 
@@ -56,127 +56,127 @@ Notes:
  - existing data in the local Neos instance will be left unchanged
  - older Beach instances may use a namespace called "beach"
 `,
-	Args: cobra.ExactArgs(0),
-	Run:  handleResourceDownloadRun,
+    Args: cobra.ExactArgs(0),
+    Run:  handleResourceDownloadRun,
 }
 
 func init() {
-	resourceDownloadCmd.Flags().StringVar(&instanceIdentifier, "instance", "", "instance identifier of the Beach instance to download from, eg. 'instance-123abc45-def6-7890-abcd-1234567890ab'")
-	resourceDownloadCmd.Flags().StringVar(&projectNamespace, "namespace", "", "The project namespace of the Beach instance to download from, eg. 'beach-project-123abc45-def6-7890-abcd-1234567890ab'")
-	resourceDownloadCmd.Flags().StringVar(&clusterIdentifier, "cluster", "", "The cluster identifier of the Beach instance to download from, eg. 'h9acc4'")
-	resourceDownloadCmd.Flags().StringVar(&sourceBucketName, "bucket", "", "name of the bucket to download resources from")
-	resourceDownloadCmd.Flags().StringVar(&targetResourcesPath, "resources-path", "", "custom path where to store the downloaded resources, e.g. 'Data/Persistent/Protected'")
-	resourceDownloadCmd.Flags().BoolVar(&synchronize, "sync", false, "Skip unchanged existing files")
+    resourceDownloadCmd.Flags().StringVar(&instanceIdentifier, "instance", "", "instance identifier of the Beach instance to download from, eg. 'instance-123abc45-def6-7890-abcd-1234567890ab'")
+    resourceDownloadCmd.Flags().StringVar(&projectNamespace, "namespace", "", "The project namespace of the Beach instance to download from, eg. 'beach-project-123abc45-def6-7890-abcd-1234567890ab'")
+    resourceDownloadCmd.Flags().StringVar(&clusterIdentifier, "cluster", "", "The cluster identifier of the Beach instance to download from, eg. 'h9acc4'")
+    resourceDownloadCmd.Flags().StringVar(&sourceBucketName, "bucket", "", "name of the bucket to download resources from")
+    resourceDownloadCmd.Flags().StringVar(&targetResourcesPath, "resources-path", "", "custom path where to store the downloaded resources, e.g. 'Data/Persistent/Protected'")
+    resourceDownloadCmd.Flags().BoolVar(&synchronize, "sync", false, "Skip unchanged existing files")
 
-	_ = resourceDownloadCmd.MarkFlagRequired("instance")
-	_ = resourceDownloadCmd.MarkFlagRequired("namespace")
-	rootCmd.AddCommand(resourceDownloadCmd)
+    _ = resourceDownloadCmd.MarkFlagRequired("instance")
+    _ = resourceDownloadCmd.MarkFlagRequired("namespace")
+    rootCmd.AddCommand(resourceDownloadCmd)
 }
 
 func handleResourceDownloadRun(cmd *cobra.Command, args []string) {
-	sandbox, err := beachsandbox.GetActiveSandbox()
-	if err != nil {
-		log.Fatal("Could not activate sandbox: ", err)
-		return
-	}
+    sandbox, err := beachsandbox.GetActiveSandbox()
+    if err != nil {
+        log.Fatal("Could not activate sandbox: ", err)
+        return
+    }
 
-	if targetResourcesPath == "" {
-		targetResourcesPath = sandbox.ProjectDataPersistentResourcesPath
-	}
+    if targetResourcesPath == "" {
+        targetResourcesPath = sandbox.ProjectDataPersistentResourcesPath
+    }
 
-	_, err = os.Stat(targetResourcesPath)
-	if err != nil {
-		log.Fatal(fmt.Sprintf("The path %v does not exist", targetResourcesPath))
-		return
-	}
+    _, err = os.Stat(targetResourcesPath)
+    if err != nil {
+        log.Fatal(fmt.Sprintf("The path %v does not exist", targetResourcesPath))
+        return
+    }
 
-	err, bucketNameFromCredentials, privateKeyDecoded := retrieveCloudStorageCredentials(instanceIdentifier, projectNamespace, clusterIdentifier)
-	if err != nil {
-		log.Fatal(err)
-		return
-	}
+    err, bucketNameFromCredentials, privateKeyDecoded := retrieveCloudStorageCredentials(instanceIdentifier, projectNamespace, clusterIdentifier)
+    if err != nil {
+        log.Fatal(err)
+        return
+    }
 
-	if sourceBucketName == "" {
-		sourceBucketName = bucketNameFromCredentials
-	}
+    if sourceBucketName == "" {
+        sourceBucketName = bucketNameFromCredentials
+    }
 
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithCredentialsJSON(privateKeyDecoded))
-	if err != nil {
-		log.Fatal(fmt.Sprintf("Failed to initialize cloud storage client: %v", err))
-		return
-	}
+    ctx := context.Background()
+    client, err := storage.NewClient(ctx, option.WithCredentialsJSON(privateKeyDecoded))
+    if err != nil {
+        log.Fatal(fmt.Sprintf("Failed to initialize cloud storage client: %v", err))
+        return
+    }
 
-	log.Info(fmt.Sprintf("Downloading resources from bucket %v to local directory %v ...", sourceBucketName, targetResourcesPath))
+    log.Info(fmt.Sprintf("Downloading resources from bucket %v to local directory %v ...", sourceBucketName, targetResourcesPath))
 
-	bucket := client.Bucket(sourceBucketName)
-	it := bucket.Objects(ctx, nil)
-	for {
-		attributes, err := it.Next()
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			log.Error(err)
-		} else {
-			source := bucket.Object(attributes.Name)
-			targetPathAndFilename := filepath.Join(targetResourcesPath, getRelativePersistentResourcePathByHash(attributes.Name), filepath.Base(attributes.Name))
-
-			err = os.MkdirAll(filepath.Dir(targetPathAndFilename), 0755)
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-
-      if synchronize == true {
-        if checkFileExists(targetPathAndFilename, attributes) {
-          log.Debug("Skipped " + attributes.Name + " as it already exists");
-          continue
+    bucket := client.Bucket(sourceBucketName)
+    it := bucket.Objects(ctx, nil)
+    for {
+        attributes, err := it.Next()
+        if errors.Is(err, iterator.Done) {
+            break
         }
-      }
+        if err != nil {
+            log.Error(err)
+        } else {
+            source := bucket.Object(attributes.Name)
+            targetPathAndFilename := filepath.Join(targetResourcesPath, getRelativePersistentResourcePathByHash(attributes.Name), filepath.Base(attributes.Name))
 
-			file, err := os.OpenFile(targetPathAndFilename, os.O_RDWR|os.O_CREATE, 0644)
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-			reader, err := source.NewReader(ctx)
-			if err != nil {
-				log.Fatal(err)
-				return
-			}
-			if _, err := io.Copy(file, reader); err != nil {
-				log.Fatal(err)
-				return
-			}
-			if err := reader.Close(); err != nil {
-				log.Fatal(err)
-				return
-			}
-			log.Debug("Downloaded " + attributes.Name)
-		}
-	}
+            err = os.MkdirAll(filepath.Dir(targetPathAndFilename), 0755)
+            if err != nil {
+                log.Fatal(err)
+                return
+            }
 
-	log.Info("Done")
-	return
+            if synchronize == true {
+                if checkFileExists(targetPathAndFilename, attributes) {
+                    log.Debug("Skipped " + attributes.Name + " as it already exists")
+                    continue
+                }
+            }
+
+            file, err := os.OpenFile(targetPathAndFilename, os.O_RDWR|os.O_CREATE, 0644)
+            if err != nil {
+                log.Fatal(err)
+                return
+            }
+            reader, err := source.NewReader(ctx)
+            if err != nil {
+                log.Fatal(err)
+                return
+            }
+            if _, err := io.Copy(file, reader); err != nil {
+                log.Fatal(err)
+                return
+            }
+            if err := reader.Close(); err != nil {
+                log.Fatal(err)
+                return
+            }
+            log.Debug("Downloaded " + attributes.Name)
+        }
+    }
+
+    log.Info("Done")
+    return
 }
 
 func checkFileExists(targetPathAndFilename string, attributes *storage.ObjectAttrs) bool {
-	if _, err := os.Stat(targetPathAndFilename); err == nil {
-		file, err := os.Open(targetPathAndFilename)
-		if err != nil {
-				return false
-		}
-		defer file.Close()
+    if _, err := os.Stat(targetPathAndFilename); err == nil {
+        file, err := os.Open(targetPathAndFilename)
+        if err != nil {
+            return false
+        }
+        defer file.Close()
 
-		crc32c := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-		if _, err := io.Copy(crc32c, file); err != nil {
-				return false
-		}
+        crc32c := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+        if _, err := io.Copy(crc32c, file); err != nil {
+            return false
+        }
 
-		if crc32c.Sum32() == attributes.CRC32C {
-			return true
-		}
-	}
-	return false
+        if crc32c.Sum32() == attributes.CRC32C {
+            return true
+        }
+    }
+    return false
 }

--- a/cmd/beach/cmd/resource-download.go
+++ b/cmd/beach/cmd/resource-download.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/resource-upload.go
+++ b/cmd/beach/cmd/resource-upload.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/restart.go
+++ b/cmd/beach/cmd/restart.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/resume.go
+++ b/cmd/beach/cmd/resume.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/root.go
+++ b/cmd/beach/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/setup-https.go
+++ b/cmd/beach/cmd/setup-https.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/setup.go
+++ b/cmd/beach/cmd/setup.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/start.go
+++ b/cmd/beach/cmd/start.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/status.go
+++ b/cmd/beach/cmd/status.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/stop.go
+++ b/cmd/beach/cmd/stop.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/beach/cmd/version.go
+++ b/cmd/beach/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,6 +29,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Beach",
 	Long:  `If version numbers are important to you, this command will be your favorite: it displays a version!`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Local Beach %s © 2019-2024 Robert Lemke / Flownative GmbH \n", version.Version)
+		fmt.Printf("Local Beach %s © 2019-2025 Robert Lemke / Flownative GmbH \n", version.Version)
 	},
 }

--- a/cmd/beach/main.go
+++ b/cmd/beach/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/beachsandbox/beachsandbox.go
+++ b/pkg/beachsandbox/beachsandbox.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/beachsandbox/helpers.go
+++ b/pkg/beachsandbox/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/path/path_darwin.go
+++ b/pkg/path/path_darwin.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/path/path_linux.go
+++ b/pkg/path/path_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Robert Lemke, Karsten Dambekalns, Christian Müller
+// Copyright 2019-2025 Robert Lemke, Karsten Dambekalns, Christian Müller
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
That allows us to run "beach exec" in non-interactive TTYs such as the one used by Claude and other AI agents.